### PR TITLE
DEV: Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# DEPRECATED
+
+-------
+
+See [Discourse Meta - Hamburger Theme Selector](https://meta.discourse.org/t/hamburger-theme-selector/61210) for more information.

--- a/javascripts/discourse/api-initializers/init-theme.js
+++ b/javascripts/discourse/api-initializers/init-theme.js
@@ -1,110 +1,23 @@
-import $ from "jquery";
-import { h } from "virtual-dom";
+import { addGlobalNotice } from "discourse/components/global-notice";
 import { apiInitializer } from "discourse/lib/api";
-import { i18n } from "discourse-i18n";
+import getURL from "discourse/lib/get-url";
 
 export default apiInitializer((api) => {
-  let themeSelector = require("discourse/lib/theme-selector");
+  if (api.getCurrentUser()?.admin) {
+    const themeId = themePrefix("foo").match(
+      /theme_translations\.(\d+)\.foo/
+    )[1];
+    const themeURL = getURL(`/admin/customize/themes/${themeId}`);
 
-  api.createWidget("theme-selector", {
-    buildKey: () => `theme-selector`,
-
-    defaultState() {
-      return { currentThemeId: themeSelector.currentThemeId() };
-    },
-
-    click(event) {
-      let $target = $(event.target);
-      let id = $target.data("id");
-      let user = api.getCurrentUser();
-
-      if (user) {
-        user.findDetails().then((detailedUser) => {
-          let seq = detailedUser.get("user_option.theme_key_seq");
-          this.setTheme(id, seq);
-        });
-      } else {
-        this.setTheme(id);
+    addGlobalNotice(
+      `<b>Admin notice:</b> you're using the <em><a href="https://meta.discourse.org/t/hamburger-theme-selector/61210">discourse-hamburger-theme-selector</a></em> theme component which was discontinued. ` +
+        `You should <a href="${themeURL}">remove this theme component</a>.`,
+      "discourse-hamburger-theme-selector",
+      {
+        dismissable: true,
+        level: "warn",
+        dismissDuration: moment.duration("1", "hour"),
       }
-
-      return true;
-    },
-
-    setTheme(themeId, seq = 0) {
-      if (themeId == null) {
-        return;
-      }
-      themeSelector.setLocalTheme([themeId], seq);
-      this.state.currentThemeId = themeId;
-      if (settings.immediate_reload) {
-        window.location.reload();
-      } else {
-        themeSelector.previewTheme([themeId]);
-      }
-      this.scheduleRerender();
-    },
-
-    themeHtml(currentThemeId) {
-      let themes = themeSelector.listThemes(this.site);
-      if (themes && themes.length > 1) {
-        return themes.map((theme) => {
-          let name = [theme.name];
-          if (theme.id === currentThemeId) {
-            name.push("\xa0" + "*");
-          }
-          return h(
-            "li",
-            { attributes: { "data-name": theme.name } },
-            h("a.widget-link", { attributes: { "data-id": theme.id } }, name)
-          );
-        });
-      }
-    },
-
-    html(attrs, state) {
-      let themeHtml = this.themeHtml(state.currentThemeId);
-      let sectionHeader = null;
-      const sectionHeaderText = i18n(
-        themePrefix("hamburger_menu.theme_selector")
-      );
-
-      if (!themeHtml) {
-        return;
-      }
-
-      if (settings.show_section_header) {
-        let user = api.getCurrentUser();
-        let sectionHeaderLink = null;
-        if (user) {
-          sectionHeaderLink = h(
-            "a.widget-link",
-            { href: "/my/preferences/interface" },
-            sectionHeaderText
-          );
-        } else {
-          sectionHeaderLink = h("span", {}, sectionHeaderText);
-        }
-        sectionHeader = h(
-          "li",
-          {
-            style:
-              "width: 100%;" + (user == null ? "padding: 0.25em 0.5em;" : null),
-          },
-          sectionHeaderLink
-        );
-      }
-
-      return [
-        h("ul.menu-links.columned", [sectionHeader, themeHtml]),
-        h(".clearfix"),
-        h("hr"),
-      ];
-    },
-  });
-
-  api.decorateWidget("menu-links:before", (helper) => {
-    if (helper.attrs.name === "footer-links") {
-      return [helper.widget.attach("theme-selector")];
-    }
-  });
+    );
+  }
 });


### PR DESCRIPTION
The `theme-selector` widget has been removed, and an admin-only global notice has been added to inform about the deprecation of the `discourse-hamburger-theme-selector` theme component. Updated README with relevant deprecation details.